### PR TITLE
Add Units Explorer Page

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,16 +1,22 @@
-import type { Metadata } from "next";
-import { Inter } from "next/font/google";
-import "./globals.css";
-import { QueryProvider } from "./providers";
+// apps/web/src/app/layout.tsx
+import type { Metadata } from 'next'
+import { Inter } from 'next/font/google'
+import './globals.css'
+import { QueryProvider } from './providers'
+import Link from 'next/link'
 
-const inter = Inter({ subsets: ["latin"] });
+const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
-  title: "TFT Team Planner",
-  description: "Build your perfect Teamfight Tactics compositions for Set 15",
-};
+  title: 'TFT Team Planner',
+  description: 'Build your perfect Teamfight Tactics compositions for Set 15',
+}
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
   return (
     <html lang="en">
       <body className={inter.className}>
@@ -18,32 +24,40 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <div className="min-h-screen bg-background">
             <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
               <div className="container mx-auto flex h-16 items-center justify-between px-4">
-                <div className="flex items-center gap-2">
+                <Link href="/" className="flex items-center gap-2 hover:opacity-80 transition-opacity">
                   <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-blue-600 to-purple-600 flex items-center justify-center">
                     <span className="text-white font-bold text-sm">TFT</span>
                   </div>
                   <h1 className="text-xl font-bold">Team Planner</h1>
-                </div>
+                </Link>
                 <nav className="flex items-center gap-6">
-                  <a
-                    href="/"
+                  <Link 
+                    href="/" 
                     className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
                   >
                     Traits
-                  </a>
-                  <a
-                    href="/builder"
+                  </Link>
+                  <Link 
+                    href="/units" 
+                    className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    Champions
+                  </Link>
+                  <Link 
+                    href="/builder" 
                     className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
                   >
                     Team Builder
-                  </a>
+                  </Link>
                 </nav>
               </div>
             </header>
-            <main className="container mx-auto px-4 py-8">{children}</main>
+            <main className="container mx-auto px-4 py-8">
+              {children}
+            </main>
           </div>
         </QueryProvider>
       </body>
     </html>
-  );
+  )
 }

--- a/apps/web/src/app/units/page.tsx
+++ b/apps/web/src/app/units/page.tsx
@@ -1,0 +1,5 @@
+import { UnitsExplorer } from '@/components/units-explorer'
+
+export default function UnitsPage() {
+  return <UnitsExplorer />
+}

--- a/apps/web/src/components/trait-card.tsx
+++ b/apps/web/src/components/trait-card.tsx
@@ -1,50 +1,48 @@
-"use client";
+'use client'
 
-import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { Card, CardHeader, CardTitle, CardContent } from "./ui/card";
-import { Badge } from "./ui/badge";
-import { fetchUnits } from "@/lib/api";
-import { ChevronDown, ChevronRight, Users } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Card, CardHeader, CardTitle, CardContent } from './ui/card'
+import { Badge } from './ui/badge'
+import { UnitCardWithDetails } from './unit-card-with-details'
+import { fetchUnits } from '@/lib/api'
+import { ChevronDown, ChevronRight, Users } from 'lucide-react'
+import { cn } from '@/lib/utils'
 
 interface Trait {
-  name: string;
-  category: "Class" | "Origin" | null;
-  unitCount: number;
+  name: string
+  category: "Class" | "Origin" | null
+  unitCount: number
   tiers: Array<{
-    minUnits: number;
-    note?: string;
-  }>;
+    minUnits: number
+    note?: string
+  }>
 }
 
 interface TraitCardProps {
-  trait: Trait;
+  trait: Trait
 }
 
 export function TraitCard({ trait }: TraitCardProps) {
-  const [isExpanded, setIsExpanded] = useState(false);
-
+  const [isExpanded, setIsExpanded] = useState(false)
+  
   const { data: unitsData, isLoading } = useQuery({
-    queryKey: ["units", trait.name],
+    queryKey: ['units', trait.name],
     queryFn: () => fetchUnits({ trait: trait.name, limit: 100 }),
-    enabled: isExpanded,
-  });
+    enabled: isExpanded
+  })
 
   const getCategoryVariant = (category: string | null) => {
     switch (category) {
-      case "Class":
-        return "class";
-      case "Origin":
-        return "origin";
-      default:
-        return "default";
+      case 'Class': return 'class'
+      case 'Origin': return 'origin'
+      default: return 'default'
     }
-  };
+  }
 
   return (
     <Card className="group cursor-pointer overflow-hidden">
-      <CardHeader
+      <CardHeader 
         className="pb-3 hover:bg-muted/50 transition-colors"
         onClick={() => setIsExpanded(!isExpanded)}
       >
@@ -59,10 +57,12 @@ export function TraitCard({ trait }: TraitCardProps) {
               <CardTitle className="text-lg font-bold">{trait.name}</CardTitle>
             </div>
             {trait.category && (
-              <Badge variant={getCategoryVariant(trait.category)}>{trait.category}</Badge>
+              <Badge variant={getCategoryVariant(trait.category)}>
+                {trait.category}
+              </Badge>
             )}
           </div>
-
+          
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
             <Users className="h-4 w-4" />
             <span className="font-medium">{trait.unitCount}</span>
@@ -72,7 +72,11 @@ export function TraitCard({ trait }: TraitCardProps) {
         {/* Trait Tiers Preview */}
         <div className="flex flex-wrap gap-1 mt-2">
           {trait.tiers.map((tier, index) => (
-            <Badge key={index} variant="outline" className="text-xs px-2 py-0.5">
+            <Badge 
+              key={index} 
+              variant="outline" 
+              className="text-xs px-2 py-0.5"
+            >
               {tier.minUnits}
               {tier.note && ` (${tier.note})`}
             </Badge>
@@ -86,42 +90,19 @@ export function TraitCard({ trait }: TraitCardProps) {
             <h4 className="font-semibold text-sm text-muted-foreground uppercase tracking-wide">
               Champions ({trait.unitCount})
             </h4>
-
+            
             {isLoading ? (
               <div className="flex items-center justify-center py-8">
                 <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary"></div>
               </div>
             ) : (
-              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2">
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
                 {unitsData?.items?.map((unit: any) => (
-                  <div
+                  <UnitCardWithDetails
                     key={unit.id}
-                    className={cn(
-                      "p-3 rounded-lg border text-center transition-all hover:shadow-sm",
-                      "bg-background hover:bg-muted/50",
-                    )}
-                  >
-                    <div className="flex items-center justify-between mb-1">
-                      <span className="font-medium text-sm truncate flex-1">{unit.name}</span>
-                      <Badge
-                        variant="outline"
-                        className="ml-2 h-5 w-5 p-0 rounded-full text-xs flex items-center justify-center"
-                      >
-                        {unit.cost}
-                      </Badge>
-                    </div>
-
-                    <div className="flex flex-wrap gap-1">
-                      {unit.traits
-                        .filter((t: any) => t.name !== trait.name)
-                        .slice(0, 2)
-                        .map((t: any) => (
-                          <Badge key={t.name} variant="secondary" className="text-xs px-1.5 py-0">
-                            {t.name}
-                          </Badge>
-                        ))}
-                    </div>
-                  </div>
+                    unit={unit}
+                    className="h-full"
+                  />
                 ))}
               </div>
             )}
@@ -129,5 +110,5 @@ export function TraitCard({ trait }: TraitCardProps) {
         </CardContent>
       )}
     </Card>
-  );
+  )
 }

--- a/apps/web/src/components/traits-explorer.tsx
+++ b/apps/web/src/components/traits-explorer.tsx
@@ -1,36 +1,54 @@
-"use client";
+'use client'
 
-import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { fetchTraits } from "@/lib/api";
-import { TraitCard } from "./trait-card";
-import { Input } from "./ui/input";
-import { Badge } from "./ui/badge";
-import { Search, Filter } from "lucide-react";
+import { useState, useCallback, useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { fetchTraits } from '@/lib/api'
+import { TraitCard } from './trait-card'
+import { Input } from './ui/input'
+import { Badge } from './ui/badge'
+import { Search, Filter } from 'lucide-react'
 
 export function TraitsExplorer() {
-  const [search, setSearch] = useState("");
-  const [categoryFilter, setCategoryFilter] = useState<string | null>(null);
+  const [search, setSearch] = useState('')
+  const [categoryFilter, setCategoryFilter] = useState<string | null>(null)
+
+  // Debounce search to avoid too many API calls
+  const [debouncedSearch, setDebouncedSearch] = useState('')
+  
+  // Use useCallback to prevent unnecessary re-renders
+  const handleSearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+    setSearch(value)
+    
+    // Debounce the API call
+    const timeoutId = setTimeout(() => {
+      setDebouncedSearch(value)
+    }, 300)
+    
+    return () => clearTimeout(timeoutId)
+  }, [])
 
   const { data, isLoading, error } = useQuery({
-    queryKey: ["traits", { search, limit: 100 }],
-    queryFn: () => fetchTraits({ search, limit: 100 }),
-  });
+    queryKey: ['traits', { search: debouncedSearch, limit: 100 }],
+    queryFn: () => fetchTraits({ search: debouncedSearch, limit: 100 })
+  })
 
-  const filteredTraits =
-    data?.items?.filter((trait: any) => {
-      if (categoryFilter && trait.category !== categoryFilter) return false;
-      return true;
-    }) || [];
+  // Memoize filtered traits to prevent unnecessary re-renders
+  const filteredTraits = useMemo(() => {
+    return data?.items?.filter((trait: any) => {
+      if (categoryFilter && trait.category !== categoryFilter) return false
+      return true
+    }) || []
+  }, [data?.items, categoryFilter])
 
-  const categories = ["Class", "Origin"];
+  const categories = ['Class', 'Origin']
 
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-12">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
       </div>
-    );
+    )
   }
 
   if (error) {
@@ -38,7 +56,7 @@ export function TraitsExplorer() {
       <div className="text-center py-12">
         <p className="text-muted-foreground">Failed to load traits</p>
       </div>
-    );
+    )
   }
 
   return (
@@ -58,11 +76,13 @@ export function TraitsExplorer() {
           <Input
             placeholder="Search traits..."
             value={search}
-            onChange={(e) => setSearch(e.target.value)}
+            onChange={handleSearchChange}
             className="pl-10"
+            // Prevent re-render from losing focus
+            key="search-input"
           />
         </div>
-
+        
         <div className="flex items-center gap-2">
           <Filter className="h-4 w-4 text-muted-foreground" />
           <div className="flex gap-2">
@@ -73,7 +93,7 @@ export function TraitsExplorer() {
             >
               All
             </Badge>
-            {categories.map((category) => (
+            {categories.map(category => (
               <Badge
                 key={category}
                 variant={categoryFilter === category ? "default" : "outline"}
@@ -89,7 +109,7 @@ export function TraitsExplorer() {
 
       {/* Results Count */}
       <div className="text-sm text-muted-foreground">
-        Showing {filteredTraits.length} trait{filteredTraits.length !== 1 ? "s" : ""}
+        Showing {filteredTraits.length} trait{filteredTraits.length !== 1 ? 's' : ''}
       </div>
 
       {/* Traits Grid */}
@@ -105,5 +125,5 @@ export function TraitsExplorer() {
         </div>
       )}
     </div>
-  );
+  )
 }

--- a/apps/web/src/components/unit-card-with-details.tsx
+++ b/apps/web/src/components/unit-card-with-details.tsx
@@ -1,0 +1,162 @@
+'use client'
+
+import { useState } from 'react'
+import { Badge } from './ui/badge'
+import { Card, CardContent } from './ui/card'
+import { cn } from '@/lib/utils'
+import { Sword, Shield, Heart, Zap } from 'lucide-react'
+
+interface Unit {
+  id: string
+  name: string
+  cost: number
+  traits: Array<{
+    name: string
+    category: "Class" | "Origin" | null
+  }>
+  baseStats: any
+  ability: any
+  role?: string | null
+}
+
+interface UnitCardWithDetailsProps {
+  unit: Unit
+  className?: string
+  onClick?: () => void
+}
+
+export function UnitCardWithDetails({ unit, className, onClick }: UnitCardWithDetailsProps) {
+  const [showDetails, setShowDetails] = useState(false)
+
+  const getCostColor = (cost: number) => {
+    const colors = {
+      1: 'bg-gray-500',
+      2: 'bg-green-500', 
+      3: 'bg-blue-500',
+      4: 'bg-purple-500',
+      5: 'bg-yellow-500'
+    }
+    return colors[cost as keyof typeof colors] || 'bg-gray-500'
+  }
+
+  const formatStats = (stats: any) => {
+    if (!stats || typeof stats !== 'object') return null
+    
+    // Extract common stats from baseStats
+    const hp = Array.isArray(stats.hp) ? stats.hp[0] : stats.hp
+    const ad = Array.isArray(stats.ad) ? stats.ad[0] : stats.ad
+    const armor = stats.armor
+    const mr = stats.mr
+    const attackSpeed = stats.as
+    const range = stats.range
+    
+    return { hp, ad, armor, mr, attackSpeed, range }
+  }
+
+  const baseStats = formatStats(unit.baseStats)
+
+  return (
+    <div className="relative">
+      <Card
+        className={cn(
+          "cursor-pointer transition-all duration-200 hover:shadow-lg hover:scale-105",
+          "bg-background hover:bg-muted/50",
+          className
+        )}
+        onClick={onClick}
+        onMouseEnter={() => setShowDetails(true)}
+        onMouseLeave={() => setShowDetails(false)}
+      >
+        <CardContent className="p-3">
+          <div className="flex items-center justify-between mb-2">
+            <span className="font-medium text-sm truncate flex-1">
+              {unit.name}
+            </span>
+            <Badge 
+              className={cn(
+                "ml-2 h-6 w-6 p-0 rounded-full text-xs flex items-center justify-center text-white font-bold",
+                getCostColor(unit.cost)
+              )}
+            >
+              {unit.cost}
+            </Badge>
+          </div>
+          
+          {/* Role */}
+          {unit.role && (
+            <div className="text-xs text-muted-foreground mb-1 font-medium">
+              {unit.role}
+            </div>
+          )}
+          
+          {/* Traits */}
+          <div className="flex flex-wrap gap-1">
+            {unit.traits.slice(0, 3).map((trait) => (
+              <Badge 
+                key={trait.name} 
+                variant={trait.category === 'Class' ? 'class' : 'origin'} 
+                className="text-xs px-1.5 py-0"
+              >
+                {trait.name}
+              </Badge>
+            ))}
+            {unit.traits.length > 3 && (
+              <span className="text-xs text-muted-foreground">+{unit.traits.length - 3}</span>
+            )}
+          </div>
+
+          {/* Ability name preview */}
+          {unit.ability?.name && (
+            <div className="text-xs text-primary font-medium mt-1 truncate">
+              {unit.ability.name}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Hover Details Tooltip */}
+      {showDetails && baseStats && (
+        <div className="absolute z-50 bottom-full left-1/2 transform -translate-x-1/2 mb-2 p-3 bg-card border rounded-lg shadow-lg min-w-[200px]">
+          <div className="text-sm font-semibold mb-2">{unit.name}</div>
+          
+          {/* Base Stats Grid */}
+          <div className="grid grid-cols-2 gap-2 text-xs">
+            <div className="flex items-center gap-1">
+              <Heart className="h-3 w-3 text-red-500" />
+              <span>{baseStats.hp}</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <Sword className="h-3 w-3 text-orange-500" />
+              <span>{baseStats.ad}</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <Shield className="h-3 w-3 text-blue-500" />
+              <span>{baseStats.armor}</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <Zap className="h-3 w-3 text-purple-500" />
+              <span>{baseStats.mr}</span>
+            </div>
+          </div>
+
+          {/* Range and Attack Speed */}
+          <div className="mt-2 text-xs text-muted-foreground">
+            Range: {baseStats.range} • AS: {baseStats.attackSpeed}
+          </div>
+
+          {/* Ability Preview */}
+          {unit.ability?.name && (
+            <div className="mt-2 pt-2 border-t">
+              <div className="text-xs font-medium text-primary">{unit.ability.name}</div>
+              {unit.ability.tags && (
+                <div className="text-xs text-muted-foreground mt-1">
+                  {unit.ability.tags.slice(0, 3).join(', ')}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/unit-detail-card.tsx
+++ b/apps/web/src/components/unit-detail-card.tsx
@@ -1,0 +1,289 @@
+'use client'
+
+import { useState } from 'react'
+import { Badge } from './ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
+import { cn } from '@/lib/utils'
+import { Heart, Sword, Shield, Zap, Target, ChevronDown, ChevronRight } from 'lucide-react'
+
+interface Unit {
+  id: string
+  name: string
+  cost: number
+  traits: Array<{
+    name: string
+    category: "Class" | "Origin" | null
+  }>
+  baseStats: any
+  ability: any
+  role?: string | null
+}
+
+interface UnitDetailCardProps {
+  unit: Unit
+  viewMode: 'grid' | 'list'
+}
+
+export function UnitDetailCard({ unit, viewMode }: UnitDetailCardProps) {
+  const [isExpanded, setIsExpanded] = useState(false)
+
+  const getCostColor = (cost: number) => {
+    const colors = {
+      1: 'bg-gray-500 border-gray-600',
+      2: 'bg-green-500 border-green-600', 
+      3: 'bg-blue-500 border-blue-600',
+      4: 'bg-purple-500 border-purple-600',
+      5: 'bg-yellow-500 border-yellow-600'
+    }
+    return colors[cost as keyof typeof colors] || 'bg-gray-500'
+  }
+
+  const formatStats = (stats: any) => {
+    if (!stats || typeof stats !== 'object') return null
+    
+    const hp = Array.isArray(stats.hp) ? stats.hp : [stats.hp, stats.hp, stats.hp]
+    const ad = Array.isArray(stats.ad) ? stats.ad : [stats.ad, stats.ad, stats.ad]
+    const armor = stats.armor
+    const mr = stats.mr
+    const attackSpeed = stats.as
+    const range = stats.range
+    const mana = stats.mana
+    
+    return { hp, ad, armor, mr, attackSpeed, range, mana }
+  }
+
+  const baseStats = formatStats(unit.baseStats)
+
+  if (viewMode === 'list') {
+    return (
+      <Card className="cursor-pointer hover:shadow-md transition-shadow">
+        <CardHeader 
+          className="pb-3"
+          onClick={() => setIsExpanded(!isExpanded)}
+        >
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-4">
+              <div className={cn(
+                "h-12 w-12 rounded-lg border-2 flex items-center justify-center text-white font-bold",
+                getCostColor(unit.cost)
+              )}>
+                {unit.cost}
+              </div>
+              
+              <div className="space-y-1">
+                <CardTitle className="text-lg">{unit.name}</CardTitle>
+                {unit.role && (
+                  <p className="text-sm text-muted-foreground">{unit.role}</p>
+                )}
+              </div>
+            </div>
+
+            <div className="flex items-center gap-4">
+              {/* Quick Stats */}
+              {baseStats && (
+                <div className="flex items-center gap-4 text-sm">
+                  <div className="flex items-center gap-1">
+                    <Heart className="h-4 w-4 text-red-500" />
+                    <span>{baseStats.hp[0]}</span>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <Sword className="h-4 w-4 text-orange-500" />
+                    <span>{baseStats.ad[0]}</span>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <Target className="h-4 w-4 text-blue-500" />
+                    <span>{baseStats.range}</span>
+                  </div>
+                </div>
+              )}
+
+              {isExpanded ? (
+                <ChevronDown className="h-4 w-4 text-muted-foreground" />
+              ) : (
+                <ChevronRight className="h-4 w-4 text-muted-foreground" />
+              )}
+            </div>
+          </div>
+
+          {/* Traits */}
+          <div className="flex flex-wrap gap-1 mt-2">
+            {unit.traits.map((trait) => (
+              <Badge 
+                key={trait.name} 
+                variant={trait.category === 'Class' ? 'class' : 'origin'}
+                className="text-xs"
+              >
+                {trait.name}
+              </Badge>
+            ))}
+          </div>
+        </CardHeader>
+
+        {isExpanded && (
+          <CardContent className="pt-0 border-t">
+            <div className="grid md:grid-cols-2 gap-6">
+              {/* Base Stats */}
+              {baseStats && (
+                <div className="space-y-3">
+                  <h4 className="font-semibold text-sm">Base Stats</h4>
+                  <div className="grid grid-cols-2 gap-3 text-sm">
+                    <div className="space-y-2">
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2">
+                          <Heart className="h-4 w-4 text-red-500" />
+                          <span>Health</span>
+                        </div>
+                        <span className="font-mono">{baseStats.hp.join(' / ')}</span>
+                      </div>
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2">
+                          <Sword className="h-4 w-4 text-orange-500" />
+                          <span>Attack Damage</span>
+                        </div>
+                        <span className="font-mono">{baseStats.ad.join(' / ')}</span>
+                      </div>
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2">
+                          <Shield className="h-4 w-4 text-blue-500" />
+                          <span>Armor</span>
+                        </div>
+                        <span className="font-mono">{baseStats.armor}</span>
+                      </div>
+                    </div>
+                    <div className="space-y-2">
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2">
+                          <Zap className="h-4 w-4 text-purple-500" />
+                          <span>Magic Resist</span>
+                        </div>
+                        <span className="font-mono">{baseStats.mr}</span>
+                      </div>
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2">
+                          <Target className="h-4 w-4 text-green-500" />
+                          <span>Attack Speed</span>
+                        </div>
+                        <span className="font-mono">{baseStats.attackSpeed}</span>
+                      </div>
+                      <div className="flex items-center justify-between">
+                        <span>Range</span>
+                        <span className="font-mono">{baseStats.range}</span>
+                      </div>
+                    </div>
+                  </div>
+                  
+                  {baseStats.mana && (
+                    <div className="pt-2 border-t">
+                      <div className="flex items-center justify-between text-sm">
+                        <span>Mana</span>
+                        <span className="font-mono">
+                          {baseStats.mana.start} / {baseStats.mana.max}
+                        </span>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* Ability */}
+              {unit.ability && (
+                <div className="space-y-3">
+                  <h4 className="font-semibold text-sm">Ability</h4>
+                  <div className="space-y-2">
+                    <div className="font-medium text-primary">{unit.ability.name}</div>
+                    
+                    {unit.ability.tags && (
+                      <div className="flex flex-wrap gap-1">
+                        {unit.ability.tags.map((tag: string) => (
+                          <Badge key={tag} variant="secondary" className="text-xs">
+                            {tag}
+                          </Badge>
+                        ))}
+                      </div>
+                    )}
+                    
+                    {unit.ability.text && (
+                      <p className="text-sm text-muted-foreground leading-relaxed">
+                        {unit.ability.text}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          </CardContent>
+        )}
+      </Card>
+    )
+  }
+
+  // Grid view (compact)
+  return (
+    <Card className="cursor-pointer hover:shadow-lg hover:scale-105 transition-all duration-200">
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base truncate">{unit.name}</CardTitle>
+          <Badge 
+            className={cn(
+              "h-6 w-6 p-0 rounded-full text-xs flex items-center justify-center text-white font-bold",
+              getCostColor(unit.cost)
+            )}
+          >
+            {unit.cost}
+          </Badge>
+        </div>
+        
+        {unit.role && (
+          <p className="text-xs text-muted-foreground">{unit.role}</p>
+        )}
+        
+        {/* Traits */}
+        <div className="flex flex-wrap gap-1">
+          {unit.traits.slice(0, 2).map((trait) => (
+            <Badge 
+              key={trait.name} 
+              variant={trait.category === 'Class' ? 'class' : 'origin'}
+              className="text-xs px-1.5 py-0"
+            >
+              {trait.name}
+            </Badge>
+          ))}
+          {unit.traits.length > 2 && (
+            <span className="text-xs text-muted-foreground">+{unit.traits.length - 2}</span>
+          )}
+        </div>
+      </CardHeader>
+
+      <CardContent className="pt-0">
+        {/* Quick Stats */}
+        {baseStats && (
+          <div className="grid grid-cols-2 gap-2 text-xs">
+            <div className="flex items-center gap-1">
+              <Heart className="h-3 w-3 text-red-500" />
+              <span>{baseStats.hp[0]}</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <Sword className="h-3 w-3 text-orange-500" />
+              <span>{baseStats.ad[0]}</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <Shield className="h-3 w-3 text-blue-500" />
+              <span>{baseStats.armor}</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <Target className="h-3 w-3 text-green-500" />
+              <span>{baseStats.range}</span>
+            </div>
+          </div>
+        )}
+
+        {/* Ability name */}
+        {unit.ability?.name && (
+          <div className="text-xs text-primary font-medium mt-2 truncate">
+            {unit.ability.name}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/web/src/components/units-explorer.tsx
+++ b/apps/web/src/components/units-explorer.tsx
@@ -1,0 +1,199 @@
+'use client'
+
+import { useState, useCallback, useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { fetchUnits, fetchTraits } from '@/lib/api'
+import { UnitDetailCard } from './unit-detail-card'
+import { Input } from './ui/input'
+import { Badge } from './ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
+import { Search, Filter, Grid, List } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export function UnitsExplorer() {
+  const [search, setSearch] = useState('')
+  const [debouncedSearch, setDebouncedSearch] = useState('')
+  const [selectedCost, setSelectedCost] = useState<number | undefined>()
+  const [selectedTrait, setSelectedTrait] = useState<string | undefined>()
+  const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid')
+
+  const handleSearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+    setSearch(value)
+    
+    const timeoutId = setTimeout(() => {
+      setDebouncedSearch(value)
+    }, 300)
+    
+    return () => clearTimeout(timeoutId)
+  }, [])
+
+  // Fetch units with filters
+  const { data: unitsData, isLoading: unitsLoading, error: unitsError } = useQuery({
+    queryKey: ['units', { search: debouncedSearch, cost: selectedCost, trait: selectedTrait, limit: 100 }],
+    queryFn: () => fetchUnits({ 
+      search: debouncedSearch, 
+      cost: selectedCost, 
+      trait: selectedTrait, 
+      limit: 100 
+    })
+  })
+
+  // Fetch traits for filter dropdown
+  const { data: traitsData } = useQuery({
+    queryKey: ['traits', { limit: 100 }],
+    queryFn: () => fetchTraits({ limit: 100 })
+  })
+
+  const units = unitsData?.items || []
+  const traits = traitsData?.items || []
+
+  if (unitsLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+      </div>
+    )
+  }
+
+  if (unitsError) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-muted-foreground">Failed to load units</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">Champions</h1>
+        <p className="text-muted-foreground">
+          Explore all Set 15 champions with detailed stats and abilities
+        </p>
+      </div>
+
+      {/* Filters */}
+      <Card>
+        <CardHeader className="pb-4">
+          <CardTitle className="text-lg">Filters</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {/* Search */}
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
+            <Input
+              placeholder="Search champions..."
+              value={search}
+              onChange={handleSearchChange}
+              className="pl-10"
+              key="units-search-input"
+            />
+          </div>
+
+          <div className="flex flex-wrap gap-4">
+            {/* Cost Filter */}
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium">Cost:</span>
+              <div className="flex gap-1">
+                <Badge
+                  variant={selectedCost === undefined ? "default" : "outline"}
+                  className="cursor-pointer"
+                  onClick={() => setSelectedCost(undefined)}
+                >
+                  All
+                </Badge>
+                {[1, 2, 3, 4, 5].map(cost => (
+                  <Badge
+                    key={cost}
+                    variant={selectedCost === cost ? "default" : "outline"}
+                    className="cursor-pointer"
+                    onClick={() => setSelectedCost(cost)}
+                  >
+                    {cost}★
+                  </Badge>
+                ))}
+              </div>
+            </div>
+
+            {/* Trait Filter */}
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium">Trait:</span>
+              <div className="flex gap-1 flex-wrap">
+                <Badge
+                  variant={selectedTrait === undefined ? "default" : "outline"}
+                  className="cursor-pointer"
+                  onClick={() => setSelectedTrait(undefined)}
+                >
+                  All
+                </Badge>
+                {traits.slice(0, 8).map((trait: any) => (
+                  <Badge
+                    key={trait.name}
+                    variant={selectedTrait === trait.name ? "default" : "outline"}
+                    className="cursor-pointer"
+                    onClick={() => setSelectedTrait(trait.name)}
+                  >
+                    {trait.name}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+
+            {/* View Mode */}
+            <div className="flex items-center gap-2 ml-auto">
+              <span className="text-sm font-medium">View:</span>
+              <div className="flex border rounded-md">
+                <button
+                  className={cn(
+                    "p-2 rounded-l-md transition-colors",
+                    viewMode === 'grid' ? "bg-primary text-primary-foreground" : "hover:bg-muted"
+                  )}
+                  onClick={() => setViewMode('grid')}
+                >
+                  <Grid className="h-4 w-4" />
+                </button>
+                <button
+                  className={cn(
+                    "p-2 rounded-r-md transition-colors",
+                    viewMode === 'list' ? "bg-primary text-primary-foreground" : "hover:bg-muted"
+                  )}
+                  onClick={() => setViewMode('list')}
+                >
+                  <List className="h-4 w-4" />
+                </button>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Results Count */}
+      <div className="text-sm text-muted-foreground">
+        Showing {units.length} champion{units.length !== 1 ? 's' : ''}
+      </div>
+
+      {/* Units Grid/List */}
+      <div className={cn(
+        viewMode === 'grid' 
+          ? "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4"
+          : "space-y-4"
+      )}>
+        {units.map((unit: any) => (
+          <UnitDetailCard
+            key={unit.id}
+            unit={unit}
+            viewMode={viewMode}
+          />
+        ))}
+      </div>
+
+      {units.length === 0 && (
+        <div className="text-center py-12">
+          <p className="text-muted-foreground">No champions found matching your criteria</p>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
# Add Champions Explorer Page

## Summary
Introduces a comprehensive Champions Explorer page that allows users to browse, filter, and examine all Set 15 champions with detailed stats and abilities.

## New Features
- **📋 Champions Page**: Dedicated `/units` route for champion exploration
- **🔍 Advanced Filtering**: Search by name, filter by cost (1-5★) and trait
- **👁️ Dual View Modes**: Toggle between compact grid and detailed list views
- **📊 Complete Stats Display**: Shows HP, AD, Armor, MR, Attack Speed, Range with star scaling
- **⚡ Ability Details**: Full ability descriptions, mana costs, and effect tags
- **🎯 Enhanced Tooltips**: Hover over champions in traits page for quick stat preview

## User Experience
- **Grid View**: Compact cards showing essential info and quick stats
- **List View**: Expandable cards with full stat breakdowns and ability text
- **Smart Search**: Debounced search input that maintains focus while typing
- **Visual Hierarchy**: Cost-based color coding and trait category badges
- **Responsive Design**: Optimized layouts for all screen sizes

## Technical Implementation
- **React Query Integration**: Efficient data fetching with caching
- **Component Architecture**: Reusable `UnitDetailCard` and `UnitCardWithDetails`
- **Performance**: Debounced search, memoized filters, and optimized re-renders
- **Navigation**: Updated header with "Champions" link

## Navigation
- **Traits** → Browse traits and their champion rosters
- **Champions** → Detailed champion browser (new)
- **Team Builder** → Coming soon

## API Usage
- `GET /api/v1/units` - List champions with filtering
- `GET /api/v1/traits` - For trait filter dropdown

Builds on existing API infrastructure to provide comprehensive champion exploration capabilities.